### PR TITLE
replace PHPs readfile() with a curl request to proper load the PDF files

### DIFF
--- a/Classes/Library/RepositoryAbstract.php
+++ b/Classes/Library/RepositoryAbstract.php
@@ -194,7 +194,16 @@ abstract class RepositoryAbstract
 		$uri = $this->_url . $this->_path . (empty($this->_query) ? '' : '?' . $this->_query);
 
 		if (ob_get_level()) ob_end_clean();
-		readfile($uri);
+
+		$curlRequest = curl_init();
+		curl_setopt($curlRequest, CURLOPT_URL, $uri);
+		curl_setopt($curlRequest, CURLOPT_RETURNTRANSFER, false);
+		curl_setopt($curlRequest, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($curlRequest, CURLOPT_CONNECTTIMEOUT ,30);
+		curl_setopt($curlRequest, CURLOPT_TIMEOUT, 400);
+		$fileResponse = curl_exec($curlRequest);
+		curl_close($curlRequest);
+		echo $fileResponse;
 
 		return $this;
 	}


### PR DESCRIPTION
This pull request will change the type of request for the PDF retrieval from readfile() to curl().

In some cases the readfile() function could be a problem for systems without `allow_url_fopen=On` or other file retrieval restrictions. The settings for the curl request are chosen a bit softly to ensure that problems with certificates or large downloads won't show up that often. So it also finally resolves the problem with too large PDF files.

Feel free to merge these changes to the master branch. For the NI test client all that works well.